### PR TITLE
Do not set reserved to 0

### DIFF
--- a/db.py
+++ b/db.py
@@ -47,7 +47,7 @@ def update_quota_usages_db(meta, project_id, resource, in_use):
         quota_usages.update().where(
             and_(quota_usages.c.project_id == project_id,
                  quota_usages.c.resource == resource)).values(
-                     updated_at=now, in_use=in_use, reserved=0).execute()
+                     updated_at=now, in_use=in_use).execute()
 
 
 def get_db_url(config_file):


### PR DESCRIPTION
Currently reserved is set to 0 when quota usage is updated.
When expired reservations are removed by Cinder, this may
result in negative reserved values. Since the periodic task
in Cinder takes care of expired reservations and reserved
values, we shouldn't blindly set reserved to 0.